### PR TITLE
fix grammar in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rails Icons
 
-Embed any library's icon in your Rails app. There are many icon gem's for Rails already, but none are library-agnostic. This means you need to pull in other gems or add your logic to display that one-specific icon.
+Embed any library's icon in your Rails app. There are many icon gems for Rails already, but none are library-agnostic. This means you need to pull in other gems or add your logic to display that one specific icon.
 
 Supported libraries:
 


### PR DESCRIPTION
The apostrophe is for 
- adding a possessive marker to a word: "This is John's car".
- contracting multiple words into one: "This isn't the way."

It's not needed for "gems", where the "s" marks plurality.

The hyphen is useful when two words form a single adjective, like in "This is a library-agnostic gem", where "library" internally modifies "agnostic" to change what sort of agnosticism the gem displays.  If we used notation from LISP or math we might write "((library agnostic) gem)".   But the case of "one specific icon" is different: it is one icon, and a specific icon—both "one" and "specific" are modifying "icon", so the hyphen doesn't belong.

I hope the explanations are helpful.  

Thanks for the gem—it looks promising.  ❤️