### PR TITLE
Feature/download icons from author repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.DS_Store

--- a/lib/generators/rails_icons/helpers/icon_sync_engine.rb
+++ b/lib/generators/rails_icons/helpers/icon_sync_engine.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
-require 'fileutils'
+require "fileutils"
 
 module RailsIcons
   # Pulls the latest set of icon svgs from the given repository
   class IconSyncEngine < Rails::Generators::Base
     def initialize(temp_dir, repository)
       super
-      @temp_dir = File.join(temp_dir, repository[:name])
+      @temp_dir = File.join(temp_dir, repository[:name], repository[:dir_wrapper])
       @repository = repository
     end
 
     def sync
       clone_repo
-      move_icons_folder
+      filter_icons_from_repo
       remove_non_svg_files
-    rescue StandardError => e
+    rescue => e
       say "Failed to sync icons: #{e.message}", :red
       clean_up
       raise
@@ -26,7 +26,7 @@ module RailsIcons
     # If sync fails offer to clean up any files that were downloaded
     def clean_up
       if yes?("Do you want to remove the temp files? ('#{@temp_dir}')")
-        say 'Cleaning up...'
+        say "Cleaning up..."
         FileUtils.rm_rf(@temp_dir)
       else
         say("Leaving files at: '#{@temp_dir}'")
@@ -35,33 +35,44 @@ module RailsIcons
 
     # Clone the given repo into temp_dir/<Icon set name>
     def clone_repo
-      raise 'Failed to clone Icon repository' unless system("git clone '#{@repository[:repo_url]}' '#{@temp_dir}'")
+      raise "Failed to clone Icon repository" unless system("git clone '#{@repository[:repo_url]}' '#{@temp_dir}'")
 
-      say 'Icon set cloned successfully', :green
+      say "Icon set cloned successfully", :green
     end
 
-    # Move the 'icons' folder out of the repo and
-    # delete the all other repository files
-    def move_icons_folder
-      icons_dir = File.join(@temp_dir, @repository[:icon_dir])
-
+    def filter_icons_from_repo
       raise "Failed to find the icons directory: '#{icons_dir}'" unless Dir.exist?(icons_dir)
 
       # Store the list of current items in the root directory for reference
       # when deleting files later
-      original_temp_dir_items = Dir.entries(@temp_dir) - ['.', '..']
+      original_temp_dir_items = Dir.entries(@temp_dir) - [".", ".."]
 
+      move_icons
+
+      # Remove everything in the root directory (@temp_dir) that was originally there
+      remove_files_and_folders(original_temp_dir_items)
+
+      say "Icons filtered from repository successfully.", :green
+    end
+
+    def icons_dir
+      File.join(@temp_dir, @repository[:icon_dir])
+    end
+
+    def move_icons
       # Move all contents of the icons directory to the parent directory (temp_dir)
       Dir.foreach(icons_dir) do |item|
-        next if ['.', '..'].include?(item) # Skip special directories
+        next if [".", ".."].include?(item) # Skip special directories
 
         item_path = File.join(icons_dir, item)
         # Move the item to the temp_dir (root level)
         FileUtils.mv(item_path, @temp_dir)
       end
+    end
 
+    def remove_files_and_folders(dir_items)
       # Remove everything in the root directory (@temp_dir) that was originally there
-      original_temp_dir_items.each do |item|
+      dir_items.each do |item|
         item_path = File.join(@temp_dir, item)
         if File.directory?(item_path)
           FileUtils.rm_rf(item_path) # Remove directory and its contents
@@ -69,21 +80,18 @@ module RailsIcons
           FileUtils.rm(item_path) # Remove file
         end
       end
-
-      say 'Icons moved and cleaned up successfully.', :green
     end
 
     # Some repositories have .json files inside their icon directories
     # Remove everything but the .svg files
     def remove_non_svg_files
       Dir.glob("#{@temp_dir}/**/*") do |file|
-        if File.file?(file) && File.extname(file) != '.svg'
+        if File.file?(file) && File.extname(file) != ".svg"
           FileUtils.rm(file) # Remove the file
           puts "Deleted: #{file}"
         end
       end
-      say 'Non-SVG files removed successfully.', :green
+      say "Non-SVG files removed successfully.", :green
     end
   end
 end
-

--- a/lib/generators/rails_icons/icon_repos/tabler_sync_engine.rb
+++ b/lib/generators/rails_icons/icon_repos/tabler_sync_engine.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+module RailsIcons
+  # Pulls the latest set of icon svgs from the given repository
+  class IconSyncEngine < Rails::Generators::Base
+    def initialize(temp_dir, repository)
+      super
+      @temp_dir = File.join(temp_dir, repository[:name])
+      @repository = repository
+    end
+
+    def sync
+      clone_repo
+      move_icons_folder
+      remove_non_svg_files
+    rescue StandardError => e
+      say "Failed to sync icons: #{e.message}", :red
+      clean_up
+      raise
+    end
+
+    private
+
+    # If sync fails offer to clean up any files that were downloaded
+    def clean_up
+      if yes?("Do you want to remove the temp files? ('#{@temp_dir}')")
+        say 'Cleaning up...'
+        FileUtils.rm_rf(@temp_dir)
+      else
+        say("Leaving files at: '#{@temp_dir}'")
+      end
+    end
+
+    # Clone the given repo into temp_dir/<Icon set name>
+    def clone_repo
+      raise 'Failed to clone Icon repository' unless system("git clone '#{@repository[:repo_url]}' '#{@temp_dir}'")
+
+      say 'Icon set cloned successfully', :green
+    end
+
+    # Move the 'icons' folder out of the repo and
+    # delete the all other repository files
+    def move_icons_folder
+      icons_dir = File.join(@temp_dir, @repository[:icon_dir])
+
+      raise "Failed to find the icons directory: '#{icons_dir}'" unless Dir.exist?(icons_dir)
+
+      # Store the list of current items in the root directory for reference
+      # when deleting files later
+      original_temp_dir_items = Dir.entries(@temp_dir) - ['.', '..']
+
+      # Move all contents of the icons directory to the parent directory (temp_dir)
+      Dir.foreach(icons_dir) do |item|
+        next if ['.', '..'].include?(item) # Skip special directories
+
+        item_path = File.join(icons_dir, item)
+        # Move the item to the temp_dir (root level)
+        FileUtils.mv(item_path, @temp_dir)
+      end
+
+      # Remove everything in the root directory (@temp_dir) that was originally there
+      original_temp_dir_items.each do |item|
+        item_path = File.join(@temp_dir, item)
+        if File.directory?(item_path)
+          FileUtils.rm_rf(item_path) # Remove directory and its contents
+        else
+          FileUtils.rm(item_path) # Remove file
+        end
+      end
+
+      say 'Icons moved and cleaned up successfully.', :green
+    end
+
+    # Some repositories have .json files inside their icon directories
+    # Remove everything but the .svg files
+    def remove_non_svg_files
+      Dir.glob("#{@temp_dir}/**/*") do |file|
+        if File.file?(file) && File.extname(file) != '.svg'
+          FileUtils.rm(file) # Remove the file
+          puts "Deleted: #{file}"
+        end
+      end
+      say 'Non-SVG files removed successfully.', :green
+    end
+  end
+end
+

--- a/lib/generators/rails_icons/sync_generator.rb
+++ b/lib/generators/rails_icons/sync_generator.rb
@@ -1,34 +1,90 @@
-require "fileutils"
+# frozen_string_literal: true
 
+require 'fileutils'
+
+require_relative 'icon_repos/tabler_sync_engine'
 module RailsIcons
   class SyncGenerator < Rails::Generators::Base
-    ICON_VAULT_REPO_URL = "https://github.com/Rails-Designer/rails_icons_vault.git".freeze
+    ICON_VAULT_REPO_URL = 'https://github.com/Rails-Designer/rails_icons_vault.git'
 
-    argument :libraries, type: :array, default: [], banner: "heroicons lucide tabler"
+    REPOSITORIES = {
+      heroicons: {
+        name: 'heroicons',
+        repo_url: 'https://github.com/tailwindlabs/heroicons.git',
+        icon_dir: 'src/24'
+      },
+      tabler: {
+        name: 'tabler',
+        repo_url: 'https://github.com/tabler/tabler-icons.git',
+        icon_dir: 'icons'
+      },
+      lucide: {
+        name: 'lucide',
+        repo_url: 'https://github.com/lucide-icons/lucide.git',
+        icon_dir: 'icons'
+      }
+    }
+
+    argument :libraries, type: :array, default: [], banner: 'heroicons lucide tabler'
 
     class_option :destination, type: :string, default: nil,
-      desc: "Custom destination folder for icons (default: `app/assets/svg/icons/`)"
+                               desc: 'Custom destination folder for icons (default: `app/assets/svg/icons/`)'
 
-    desc "Sync a specified icon set(s) from the Rails Icons Vault (https://github.com/Rails-Designer/rails_icons_vault)"
-    source_root File.expand_path("templates", __dir__)
+    desc 'Sync a specified icon set(s) from the Rails Icons Vault (https://github.com/Rails-Designer/rails_icons_vault)'
+    source_root File.expand_path('templates', __dir__)
 
     def sync_icons
-      icons_dir = options[:destination] || Rails.root.join("app/assets/svg/icons")
-      tmp_dir = Rails.root.join("tmp/icons")
+      icons_dir = options[:destination] || Rails.root.join('app/assets/svg/icons')
+      tmp_dir = Rails.root.join('tmp/icons')
+
+      # Prepare temp directory for sync
+      FileUtils.rm_rf(tmp_dir) if Dir.exist?(tmp_dir)
+
+      libraries.each do |set|
+        repo = REPOSITORIES[set.to_sym]
+        IconSyncEngine.new(tmp_dir, repo).sync
+
+        set_path = File.join(tmp_dir, set)
+
+        if Dir.exist?(set_path)
+          destination_path = File.join(icons_dir, set)
+
+          FileUtils.mkdir_p(destination_path)
+          FileUtils.cp_r(Dir.glob("#{set_path}/*"), destination_path)
+
+          say "Synced `#{set}` icons for set", :green
+        else
+          say "Icon set `#{set}` not found", :red
+
+          exit 1
+        end
+      end
+
+      # Clean up temp directory
+      FileUtils.rm_rf(tmp_dir)
+
+      say 'Icons synced successfully', :green
+    end
+
+    private
+
+    def oldsync
+      icons_dir = options[:destination] || Rails.root.join('app/assets/svg/icons')
+      tmp_dir = Rails.root.join('tmp/icons')
 
       FileUtils.rm_rf(tmp_dir) if Dir.exist?(tmp_dir)
       FileUtils.mkdir_p(tmp_dir)
 
       if system("git clone '#{ICON_VAULT_REPO_URL}' '#{tmp_dir}'")
-        say "Repository cloned successfully.", :green
+        say 'Repository cloned successfully.', :green
       else
-        say "Failed to clone repository.", :red
+        say 'Failed to clone repository.', :red
 
         exit 1
       end
 
       libraries.each do |set|
-        set_path = File.join(tmp_dir, "icons", set)
+        set_path = File.join(tmp_dir, 'icons', set)
 
         if Dir.exist?(set_path)
           destination_path = File.join(icons_dir, set)
@@ -46,7 +102,7 @@ module RailsIcons
 
       FileUtils.rm_rf(tmp_dir)
 
-      say "Icons synced successfully", :green
+      say 'Icons synced successfully', :green
     end
   end
 end

--- a/lib/generators/rails_icons/sync_generator.rb
+++ b/lib/generators/rails_icons/sync_generator.rb
@@ -1,108 +1,86 @@
 # frozen_string_literal: true
 
-require 'fileutils'
+require "fileutils"
 
-require_relative 'icon_repos/tabler_sync_engine'
+require_relative "helpers/icon_sync_engine"
 module RailsIcons
   class SyncGenerator < Rails::Generators::Base
-    ICON_VAULT_REPO_URL = 'https://github.com/Rails-Designer/rails_icons_vault.git'
-
     REPOSITORIES = {
       heroicons: {
-        name: 'heroicons',
-        repo_url: 'https://github.com/tailwindlabs/heroicons.git',
-        icon_dir: 'src/24'
+        name: "heroicons",
+        repo_url: "https://github.com/tailwindlabs/heroicons.git",
+        icon_dir: "src/24",
+        dir_wrapper: ""
       },
       tabler: {
-        name: 'tabler',
-        repo_url: 'https://github.com/tabler/tabler-icons.git',
-        icon_dir: 'icons'
+        name: "tabler",
+        repo_url: "https://github.com/tabler/tabler-icons.git",
+        icon_dir: "icons",
+        dir_wrapper: ""
       },
       lucide: {
-        name: 'lucide',
-        repo_url: 'https://github.com/lucide-icons/lucide.git',
-        icon_dir: 'icons'
+        name: "lucide",
+        repo_url: "https://github.com/lucide-icons/lucide.git",
+        icon_dir: "icons",
+        dir_wrapper: "/outline"
       }
-    }
+    }.freeze
 
-    argument :libraries, type: :array, default: [], banner: 'heroicons lucide tabler'
+    argument :libraries, type: :array, default: [], banner: "heroicons lucide tabler"
 
     class_option :destination, type: :string, default: nil,
-                               desc: 'Custom destination folder for icons (default: `app/assets/svg/icons/`)'
+      desc: "Custom destination folder for icons (default: `app/assets/svg/icons/`)"
 
-    desc 'Sync a specified icon set(s) from the Rails Icons Vault (https://github.com/Rails-Designer/rails_icons_vault)'
-    source_root File.expand_path('templates', __dir__)
+    desc "Sync a specified icon set(s) from the Rails Icons Vault (https://github.com/Rails-Designer/rails_icons_vault)"
+    source_root File.expand_path("templates", __dir__)
 
     def sync_icons
-      icons_dir = options[:destination] || Rails.root.join('app/assets/svg/icons')
-      tmp_dir = Rails.root.join('tmp/icons')
+      icons_dir = options[:destination] || default_icons_dir
+      tmp_dir = tmp_icons_dir
 
-      # Prepare temp directory for sync
-      FileUtils.rm_rf(tmp_dir) if Dir.exist?(tmp_dir)
+      clean_tmp_dir(tmp_dir)
 
-      libraries.each do |set|
-        repo = REPOSITORIES[set.to_sym]
-        IconSyncEngine.new(tmp_dir, repo).sync
+      libraries.each { |set| sync_icon_set(set, tmp_dir, icons_dir) }
 
-        set_path = File.join(tmp_dir, set)
-
-        if Dir.exist?(set_path)
-          destination_path = File.join(icons_dir, set)
-
-          FileUtils.mkdir_p(destination_path)
-          FileUtils.cp_r(Dir.glob("#{set_path}/*"), destination_path)
-
-          say "Synced `#{set}` icons for set", :green
-        else
-          say "Icon set `#{set}` not found", :red
-
-          exit 1
-        end
-      end
-
-      # Clean up temp directory
-      FileUtils.rm_rf(tmp_dir)
-
-      say 'Icons synced successfully', :green
+      clean_tmp_dir(tmp_dir)
     end
 
     private
 
-    def oldsync
-      icons_dir = options[:destination] || Rails.root.join('app/assets/svg/icons')
-      tmp_dir = Rails.root.join('tmp/icons')
+    def default_icons_dir
+      Rails.root.join("app/assets/svg/icons")
+    end
 
+    def tmp_icons_dir
+      Rails.root.join("tmp/icons")
+    end
+
+    def clean_tmp_dir(tmp_dir)
       FileUtils.rm_rf(tmp_dir) if Dir.exist?(tmp_dir)
-      FileUtils.mkdir_p(tmp_dir)
+    end
 
-      if system("git clone '#{ICON_VAULT_REPO_URL}' '#{tmp_dir}'")
-        say 'Repository cloned successfully.', :green
+    def sync_icon_set(set, tmp_dir, icons_dir)
+      repo = REPOSITORIES[set.to_sym]
+      IconSyncEngine.new(tmp_dir, repo).sync
+      icon_set_path = File.join(tmp_dir, set)
+
+      if Dir.exist?(icon_set_path)
+        copy_icon_set(set, icon_set_path, icons_dir)
       else
-        say 'Failed to clone repository.', :red
-
-        exit 1
+        log_icon_set_not_found(set)
       end
+    end
 
-      libraries.each do |set|
-        set_path = File.join(tmp_dir, 'icons', set)
+    def copy_icon_set(set, set_path, icons_dir)
+      destination_path = File.join(icons_dir, set)
+      FileUtils.mkdir_p(destination_path)
+      FileUtils.cp_r(Dir.glob("#{set_path}/*"), destination_path)
+      say "Synced `#{set}` icons successfully.", :green
+    end
 
-        if Dir.exist?(set_path)
-          destination_path = File.join(icons_dir, set)
-
-          FileUtils.mkdir_p(destination_path)
-          FileUtils.cp_r(Dir.glob("#{set_path}/*"), destination_path)
-
-          say "Synced `#{set}` icons for set", :green
-        else
-          say "Icon set `#{set}` not found", :red
-
-          exit 1
-        end
-      end
-
-      FileUtils.rm_rf(tmp_dir)
-
-      say 'Icons synced successfully', :green
+    def log_icon_set_not_found(set)
+      say "Icon set `#{set}` not found.", :red
+      exit 1
     end
   end
 end

--- a/lib/rails_icons/icon_configs/lucide_config.rb
+++ b/lib/rails_icons/icon_configs/lucide_config.rb
@@ -5,19 +5,19 @@ module RailsIcons
   class LucideConfig
     def config
       options = ActiveSupport::OrderedOptions.new
-      setup_lucide_outlined_config(options)
+      setup_lucide_outline_config(options)
 
       options
     end
 
     private
 
-    def setup_lucide_outlined_config(options)
+    def setup_lucide_outline_config(options)
       options.outline = ActiveSupport::OrderedOptions.new
       options.outline.default = default_outlined_options
     end
 
-    def default_outlined_options
+    def default_outline_options
       options = ActiveSupport::OrderedOptions.new
       options.stroke_width = "1.5"
       options.css = "w-6 h-6"


### PR DESCRIPTION
*Still needs a lot of polish for scalability and ability to allow users to supply any icon set.*

Let me know your thoughts!  I will keep working on the PR as I have time.

Fixes Issue: #10 

Adds a new class called `IconSyncEngine` that downloads the git repos of the icon sets, parses out the icon files, restructures the directory, and deletes everything else.

Keeping up to date with the developers of the icon sets is as easy as running the sync command and no longer relies on the [rails_icon_vault](https://github.com/Rails-Designer/rails_icons_vault).

Still todo:

- [ ] Convert static hash into user configurable hash to add and sync any icon sets that host the svgs in a git repo
- [ ] Dynamically setup the configuration options for user defined icon sets
- [ ] Improve UX of sync prompts