### PR TITLE
Remove unused line

### DIFF
--- a/lib/rails_icons/configuration.rb
+++ b/lib/rails_icons/configuration.rb
@@ -30,7 +30,6 @@ module RailsIcons
     private
 
     def set_default_config
-      @config.helper_name = "icon"
       @config.default_library = "heroicons"
       @config.default_set = "outline"
     end


### PR DESCRIPTION
This line isn't used anywhere. https://github.com/Rails-Designer/rails_icons/blob/main/lib/rails_icons/configuration.rb#L33C15-L33C26

I remember wanting to support an option to change the default `icon` helper name (which is pretty general, and maybe already in use for the app). Might still be a good feature?