### PR TITLE
Process class attributes with `class_names` helper

### DIFF
--- a/lib/rails_icons/icon/attributes.rb
+++ b/lib/rails_icons/icon/attributes.rb
@@ -9,7 +9,9 @@ module RailsIcons
 
       def attach(to:)
         @merged_attributes.each do |key, value|
-          if value.is_a?(Hash)
+          if key == :class
+            class_attribute(key, value, to)
+          elsif value.is_a?(Hash)
             hash_attributes(key, value, to)
           else
             string_attributes(key, value, to)
@@ -18,6 +20,10 @@ module RailsIcons
       end
 
       private
+
+      def class_attribute(_, value, to)
+        to[:class] = ActionController::Base.helpers.token_list(value)
+      end
 
       def hash_attributes(key, value, to)
         value.each do |nested_key, nested_value|

--- a/test/icon_test.rb
+++ b/test/icon_test.rb
@@ -24,6 +24,10 @@ class IconTest < ActiveSupport::TestCase
     assert_match(/stroke-width="3"/, icon("academic-cap", stroke_width: 3), "SVG should contain 'stroke-width=\"3\"'")
   end
 
+  test "it parses class attributes" do
+    assert_match(/class="present"/, icon("academic-cap", class: ["present": true, "not-presnt": false]), "SVG should contain 'class=\"present\"'")
+  end
+
   test "setting variant, it returns a SVG" do
     assert_nothing_raised do
       icon("academic-cap", variant: "mini")


### PR DESCRIPTION
This adds support for processing `class` attributes using [class_names](https://apidock.com/rails/ActionView/Helpers/TagHelper/token_list) helper:

```erb
<%= icon "something", class: ["text-gray-500": !due, "text-red-500": due] %>
```