### PR TITLE
Option to pass (filename) transformations upon sync

### DIFF
--- a/lib/generators/rails_icons/initializer_generator.rb
+++ b/lib/generators/rails_icons/initializer_generator.rb
@@ -23,7 +23,7 @@ module RailsIcons
       if options[:libraries].present?
         default_configuration = <<~RB.indent(2)
           config.default_library = "#{options[:libraries].first}"
-          # config.default_variant = "" # Set a default variant if multiple exist
+          # config.default_variant = "" # Set a default variant for all libraries
         RB
 
         insert_into_file INITIALIZER, default_configuration, after: "RailsIcons.configure do |config|\n"

--- a/lib/rails_icons/configuration/boxicons.rb
+++ b/lib/rails_icons/configuration/boxicons.rb
@@ -40,6 +40,14 @@ module RailsIcons
         }
       end
 
+      def transformations
+        {
+          filenames: {
+            delete_prefix: ["bxl-", "bx-", "bxs-"]
+          }
+        }
+      end
+
       def setup_regular_config(options)
         options.regular = ActiveSupport::OrderedOptions.new
         options.regular.default = default_options

--- a/lib/rails_icons/configuration/phosphor.rb
+++ b/lib/rails_icons/configuration/phosphor.rb
@@ -55,6 +55,14 @@ module RailsIcons
         }
       end
 
+      def transformations
+        {
+          filenames: {
+            delete_suffix: ["-bold", "-duotone", "-fill", "-light", "-thin"]
+          }
+        }
+      end
+
       private
 
       def setup_bold_config(options)

--- a/lib/rails_icons/sync/engine.rb
+++ b/lib/rails_icons/sync/engine.rb
@@ -40,7 +40,7 @@ module RailsIcons
         say "'#{@name}' repository cloned successfully."
       end
 
-      def process_variants = Sync::ProcessVariants.new(@temp_directory, @library).process
+      def process_variants = Sync::ProcessVariants.new(@temp_directory, @name, @library).process
 
       def remove_non_svg_files
         Pathname.glob("#{@temp_directory}/**/*")

--- a/lib/rails_icons/sync/transformations.rb
+++ b/lib/rails_icons/sync/transformations.rb
@@ -1,0 +1,27 @@
+module RailsIcons
+  module Sync
+    class Transformations < Rails::Generators::Base
+      def self.transform(filename, rules = {})
+        basename = File.basename(filename, File.extname(filename))
+
+        transformed = rules.reduce(basename) do |fn, (type, value)|
+          TRANSFORMERS.fetch(type).call(fn, value)
+        end
+
+        [transformed, File.extname(filename)].join
+      end
+
+      private
+
+      TRANSFORMERS = {
+        delete_prefix: ->(filename, prefixes) {
+          Array(prefixes).reduce(filename) { _1.delete_prefix(_2) }
+        },
+
+        delete_suffix: ->(filename, suffixes) {
+          Array(suffixes).reduce(filename) { _1.delete_suffix(_2) }
+        }
+      }
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the options to pass along “transformations” (to filenames only, for now).

This was needed for, eg Phosphor library who stores the icon filenames with the variant appended (eg. `-bold`). This removes that so icons can be added with `icon "acorn", variant: :bold` instead of `icon "acorn-bold", variant: :bold`.

