### PR TITLE
automatically downcase library arguments for generators

### DIFF
--- a/lib/generators/rails_icons/initializer_generator.rb
+++ b/lib/generators/rails_icons/initializer_generator.rb
@@ -22,7 +22,7 @@ module RailsIcons
 
       if options[:libraries].present?
         default_configuration = <<~RB.indent(2)
-          config.default_library = "#{options[:libraries].first}"
+          config.default_library = "#{options[:libraries].first&.downcase}"
           # config.default_variant = "" # Set a default variant for all libraries
         RB
 
@@ -76,7 +76,7 @@ module RailsIcons
     def create_custom_directory = FileUtils.mkdir_p(File.join(options[:destination], options[:custom]))
 
     def library_configuration
-      options[:libraries].map { RailsIcons.libraries[_1.to_sym].initializer_config }.join("\n")
+      options[:libraries].map { RailsIcons.libraries[_1.downcase.to_sym].initializer_config }.join("\n")
     end
 
     def custom_configuration

--- a/lib/generators/rails_icons/install_generator.rb
+++ b/lib/generators/rails_icons/install_generator.rb
@@ -22,6 +22,6 @@ module RailsIcons
 
     private
 
-    def attributes = ["--libraries=#{options[:libraries].join(" ")}", "--destination=#{options[:destination]}"].join(" ")
+    def attributes = ["--libraries=#{options[:libraries].map(&:downcase).join(" ")}", "--destination=#{options[:destination]}"].join(" ")
   end
 end

--- a/lib/generators/rails_icons/sync_generator.rb
+++ b/lib/generators/rails_icons/sync_generator.rb
@@ -19,7 +19,7 @@ module RailsIcons
     private
 
     def libraries
-      options[:libraries].presence || synced_libraries
+      options[:libraries].presence&.downcase || synced_libraries
     end
 
     def synced_libraries

--- a/test/generators/initializer_generator_test.rb
+++ b/test/generators/initializer_generator_test.rb
@@ -14,8 +14,8 @@ class InitializerGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "config/initializers/rails_icons.rb" do |file|
-      refute_match "Heroicons", file
-      refute_match "Tabler", file
+      refute_match "heroicons", file
+      refute_match "tabler", file
     end
   end
 
@@ -24,7 +24,7 @@ class InitializerGeneratorTest < Rails::Generators::TestCase
 
     assert_file "config/initializers/rails_icons.rb" do |file|
       assert_match "# Override Heroicon defaults", file
-      refute_match "Lucide", file
+      refute_match "lucide", file
     end
   end
 
@@ -32,17 +32,17 @@ class InitializerGeneratorTest < Rails::Generators::TestCase
     run_generator %w[--libraries=lucide]
 
     assert_file "config/initializers/rails_icons.rb" do |file|
-      assert_match "# Override Lucide defaults", file
-      refute_match "Heroicons", file
+      assert_match "# Override lucide defaults", file
+      refute_match "heroicons", file
     end
   end
 
-  test "generator creates the initializer with Phosphor library" do
+  test "generator creates the initializer with phosphor library" do
     run_generator %w[--libraries=phosphor]
 
     assert_file "config/initializers/rails_icons.rb" do |file|
-      assert_match "# Override Phosphor defaults", file
-      refute_match "Tabler", file
+      assert_match "# Override phosphor defaults", file
+      refute_match "tabler", file
     end
   end
 
@@ -50,8 +50,8 @@ class InitializerGeneratorTest < Rails::Generators::TestCase
     run_generator %w[--libraries=tabler]
 
     assert_file "config/initializers/rails_icons.rb" do |file|
-      assert_match "# Override Tabler defaults", file
-      refute_match "Heroicons", file
+      assert_match "# Override tabler defaults", file
+      refute_match "heroicons", file
     end
   end
 
@@ -60,9 +60,21 @@ class InitializerGeneratorTest < Rails::Generators::TestCase
 
     assert_file "config/initializers/rails_icons.rb" do |file|
       Rails.logger.debug "File content: #{file}"
-      assert_match "# Override Lucide defaults", file
-      assert_match "# Override Tabler defaults", file
-      refute_match "Heroicons", file
+      assert_match "# Override lucide defaults", file
+      assert_match "# Override tabler defaults", file
+      refute_match "heroicons", file
+    end
+  end
+
+  test "generator correctly downcases the library names" do
+    run_generator ["--libraries", "Lucide", "Tabler"]
+
+    assert_file "config/initializers/rails_icons.rb" do |file|
+      Rails.logger.debug "File content: #{file}"
+      assert_match "lucide", file
+      refute_match "Lucide", file
+      assert_match "tabler", file
+      refute_match "Tabler", file
     end
   end
 end


### PR DESCRIPTION
To avoid issues where capitalized library name arguments causes failures on systems that employ a case-sensitive file system. Fixes #56