### PR TITLE
Hide internal generators/classes

### DIFF
--- a/lib/rails_icons/base_generator.rb
+++ b/lib/rails_icons/base_generator.rb
@@ -2,6 +2,8 @@
 
 module RailsIcons
   class BaseGenerator < Rails::Generators::Base
+    hide!
+
     def initialize(*arguments)
       super(*arguments)
 

--- a/lib/rails_icons/sync/engine.rb
+++ b/lib/rails_icons/sync/engine.rb
@@ -6,6 +6,8 @@ require "rails_icons/sync/process_variants"
 module RailsIcons
   module Sync
     class Engine < Rails::Generators::Base
+      hide!
+
       def initialize(name)
         super
 

--- a/lib/rails_icons/sync/process_variants.rb
+++ b/lib/rails_icons/sync/process_variants.rb
@@ -6,6 +6,8 @@ require "rails_icons/sync/transformations"
 module RailsIcons
   module Sync
     class ProcessVariants < Rails::Generators::Base
+      hide!
+
       def initialize(temp_directory, name, library)
         @temp_directory, @name, @library = temp_directory, name, library
       end

--- a/lib/rails_icons/sync/transformations.rb
+++ b/lib/rails_icons/sync/transformations.rb
@@ -1,6 +1,8 @@
 module RailsIcons
   module Sync
     class Transformations < Rails::Generators::Base
+      hide!
+
       def self.transform(filename, rules = {})
         basename = File.basename(filename, File.extname(filename))
 


### PR DESCRIPTION
rails generators --help currently outputs:

```
RailsIcons:
  (rails_icons:base)
  rails_icons:initializer
  rails_icons:install
  rails_icons:sync
  rails_icons:sync:engine
  rails_icons:sync:process_variants
  rails_icons:sync:transformations
```

But the bulk of these are internal classes. Added `hide!` ([source](https://api.rubyonrails.org/classes/Rails/Generators/Base.html#method-c-hide-21)) to these to not show them anymore.

```
RailsIcons:
  rails_icons:initializer
  rails_icons:install
  rails_icons:sync
```