### PR TITLE
Add `--library` option as singular alias for `--libraries`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ bundle add rails_icons
 
 Install, choosing one of the supported libraries:
 ```bash
-rails generate rails_icons:install --libraries=LIBRARY_NAME
+rails generate rails_icons:install --library=LIBRARY_NAME
 ```
 
 **Example**
 ```bash
-rails generate rails_icons:install --libraries=heroicons
+rails generate rails_icons:install --library=heroicons
 
 # Or multiple at once
 rails generate rails_icons:install --libraries=heroicons lucide
@@ -124,7 +124,7 @@ rails generate rails_icons:sync
 
 To sync only a specific library, run:
 ```bash
-rails generate rails_icons:sync --libraries=heroicons
+rails generate rails_icons:sync --library=heroicons
 
 # Or multiple at once:
 rails generate rails_icons:sync --libraries=heroicons lucide

--- a/lib/generators/rails_icons/initializer_generator.rb
+++ b/lib/generators/rails_icons/initializer_generator.rb
@@ -8,6 +8,7 @@ module RailsIcons
 
     desc "Create the Rails Icons initializer."
 
+    class_option :library, type: :string, desc: "Choose a library (#{RailsIcons.libraries.keys.join("/")})"
     class_option :libraries, type: :array, default: [], desc: "Choose libraries (#{RailsIcons.libraries.keys.join("/")})"
     class_option :destination, type: :string, default: RailsIcons.configuration.icons_path, desc: "Specify icons folder"
     class_option :custom, type: :string, desc: "Name of the custom library"
@@ -94,7 +95,13 @@ module RailsIcons
       File.readlines(INITIALIZER).any? { _1.match?(line) }
     end
 
-    def libraries = options[:libraries].map(&:downcase)
+    def libraries
+      [options[:library], *options[:libraries]]
+        .compact_blank
+        .map(&:downcase)
+        .uniq
+        .presence || []
+    end
 
     def validatable? = true
   end

--- a/lib/generators/rails_icons/sync_generator.rb
+++ b/lib/generators/rails_icons/sync_generator.rb
@@ -9,6 +9,7 @@ module RailsIcons
 
     desc "Sync the chosen icon libraries from their respective git repos."
 
+    class_option :library, type: :string, desc: "Choose a library (#{RailsIcons.libraries.keys.join("/")})"
     class_option :libraries, type: :array, default: [], desc: "Choose libraries (#{RailsIcons.libraries.keys.join("/")})"
 
     def sync_icons = libraries.each { Sync::Engine.new(_1).sync }
@@ -16,7 +17,11 @@ module RailsIcons
     private
 
     def libraries
-      options[:libraries].map(&:downcase).presence || synced_libraries
+      [options[:library], *options[:libraries]]
+        .compact_blank
+        .map(&:downcase)
+        .uniq
+        .presence || synced_libraries
     end
 
     def synced_libraries


### PR DESCRIPTION
Syntactic sugar for syncing a single library with `bin/rails generate sync --library=phosphor`. Both options can be used together and will merge.