### PR TITLE
Pass variants to install + sync generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ rails generate rails_icons:install --library=heroicons
 
 # Or multiple at once
 rails generate rails_icons:install --libraries=heroicons lucide
+
+# Or only specific variants
+rails generate rails_icons:install --library=heroicons --variants solid outline
 ```
 
 The generator also mounts an icon preview at `/rails_icons` where you can browse and search all your available icons. This route is open by default, so restrict it in production if needed.
@@ -221,6 +224,11 @@ rails generate rails_icons:sync --library=heroicons
 
 # Or multiple at once:
 rails generate rails_icons:sync --libraries=heroicons lucide
+```
+
+To sync only specific variants for a library:
+```bash
+rails generate rails_icons:sync --library=heroicons --variants solid outline
 ```
 
 

--- a/lib/generators/rails_icons/install_generator.rb
+++ b/lib/generators/rails_icons/install_generator.rb
@@ -12,6 +12,7 @@ module RailsIcons
     class_option :libraries, type: :array, default: [], desc: "Choose libraries (#{RailsIcons.libraries.keys.join("/")})"
     class_option :destination, type: :string, default: RailsIcons.configuration.icons_path, desc: "Specify destination folder for icons"
     class_option :skip_sync, type: :boolean, default: false
+    class_option :variants, type: :array, desc: "Only sync specific variants (e.g. solid outline)"
 
     def initializer_generator
       generate("rails_icons:initializer", *attributes)
@@ -34,7 +35,9 @@ module RailsIcons
     private
 
     def attributes
-      ["--libraries=#{libraries.map(&:downcase).join(" ")}", "--destination=#{options[:destination]}"].join(" ")
+      ["--libraries=#{libraries.map(&:downcase).join(" ")}", "--destination=#{options[:destination]}"].tap do |parts|
+        parts << "--variants=#{options[:variants].join(" ")}" if options[:variants].present?
+      end.join(" ")
     end
 
     def libraries

--- a/lib/generators/rails_icons/sync_generator.rb
+++ b/lib/generators/rails_icons/sync_generator.rb
@@ -10,12 +10,17 @@ module RailsIcons
 
     class_option :library, type: :string, desc: "Choose a library (#{RailsIcons.libraries.keys.join("/")})"
     class_option :libraries, type: :array, default: [], desc: "Choose libraries (#{RailsIcons.libraries.keys.join("/")})"
+    class_option :variants, type: :array, desc: "Only sync specific variants (e.g. solid outline)"
 
     def sync_icons
-      libraries.each { |library| Icons::Sync.new(library).now }
+      libraries.each { |library| Icons::Sync.new(library, variants: variants).now }
     end
 
     private
+
+    def variants
+      options[:variants]&.map(&:to_sym)
+    end
 
     def libraries
       [options[:library], *options[:libraries]]

--- a/rails_icons.gemspec
+++ b/rails_icons.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary = "Add any icon library to a Rails app"
   spec.description = "Add any icon library to a Rails app, from Heroicons, to Lucide to Tabler (and others). Rails Icons is library-agnostic, so you can add any library while using the same interface."
-  spec.homepage = "https://railsdesigner.com/rails-icons/"
+  spec.homepage = "https://railsdesigner.com/open-source/rails-icons/"
   spec.license = "MIT"
 
   spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
Depends on https://github.com/Rails-Designer/icons/pull/17

If you know which variants you want from a library, you can use `rails generate rails_icons:install --library=heroicons --variants solid outline` and it will only download those variants.

- [ ] A nice QoL improvement would to uncomment the variants config and add those as an array (TBD in the icons gem; eg `config.libraries.heroicons.variants = [:outline, :solid]`)