### PR TITLE
Honor the from alias in sprite icons

### DIFF
--- a/lib/rails_icons/helpers/sprite_helper.rb
+++ b/lib/rails_icons/helpers/sprite_helper.rb
@@ -9,6 +9,7 @@ module RailsIcons
       #
       # @param name [String] The icon name
       # @param library [String] The icon library (defaults to RailsIcons configuration)
+      # @param from [String] Syntactic sugar for a cleanly readable view layer API (preferred over `library`)
       # @param variant [String] The icon variant (optional)
       # @param sprite_location [String] Override sprite URL (optional)
       # @param arguments [Hash] Additional arguments including class, data, stroke_width, etc.
@@ -21,10 +22,10 @@ module RailsIcons
       #   <%= sprite_icon "check", variant: "solid", library: "heroicons" %>
       #   <%= sprite_icon "heart", library: "lucide", data: { controller: "favorite" } %>
       #
-      def sprite_icon(name, library: nil, variant: nil, sprite_location: nil, **arguments)
+      def sprite_icon(name, library: nil, from: library, variant: nil, sprite_location: nil, **arguments)
         Icons::SpriteIcon.new(
           name: name,
-          library: library || RailsIcons.configuration.default_library,
+          library: from || library || RailsIcons.configuration.default_library,
           variant: variant,
           sprite_location: sprite_location,
           arguments: arguments

--- a/test/rails_icons/sprite_helper_test.rb
+++ b/test/rails_icons/sprite_helper_test.rb
@@ -27,6 +27,13 @@ class SpriteHelperTest < ActiveSupport::TestCase
     assert_match(%r{#heroicons_mini_academic-cap}, result)
   end
 
+  test "sprite_icon supports from as a library alias" do
+    result = sprite_icon("academic-cap", library: "lucide", from: "heroicons")
+
+    assert_match(%r{#heroicons_outline_academic-cap}, result)
+    refute_match(/\sfrom=/, result)
+  end
+
   test "sprite_icon with class" do
     result = sprite_icon("academic-cap", class: "size-6")
 


### PR DESCRIPTION
## Summary

- accept `from:` in `sprite_icon`, matching the existing `icon` and `encoded_icon` helper API
- prefer `from:` over `library:` while preserving the configured default-library fallback
- cover alias precedence and ensure the helper keyword is not rendered as an SVG attribute

## Why

The README states that `sprite_icon` accepts the same options as `icon`, where `from:` is the preferred library alias. Previously, `sprite_icon` captured `from:` as a generic SVG attribute, selected the wrong configured library, and rendered `from="..."` on the `<svg>` element.

## Verification

- `bundle exec rails test` (33 runs, 94 assertions)
- `bundle exec standardrb`
- `bundle exec rake`
- `gem build rails_icons.gemspec`
- manual alias/default-library/external-location attribute probes
- `git diff --check`
